### PR TITLE
Fix AGP version for Android Studio compatibility (use 8.13.1)

### DIFF
--- a/Icarus/gradle/libs.versions.toml
+++ b/Icarus/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.1"
+agp = "8.13.1"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 espressoCore = "3.7.0"


### PR DESCRIPTION
## Summary
- Downgrade Android Gradle Plugin (AGP) from 9.0.1 to 8.13.1 via `gradle/libs.versions.toml`
- Fixes Android Studio sync/build compatibility

## Testing
- Gradle sync: works
- Run on emulator:  (Hello World)