### PR TITLE
Add chosen entrants screen using entrant status query

### DIFF
--- a/Icarus/app/src/main/AndroidManifest.xml
+++ b/Icarus/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -11,6 +12,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Icarus">
+
+        <activity android:name=".ChosenEntrantsActivity" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/Icarus/app/src/main/java/com/icarus/events/ChosenEntrantsActivity.java
+++ b/Icarus/app/src/main/java/com/icarus/events/ChosenEntrantsActivity.java
@@ -1,0 +1,93 @@
+package com.icarus.events;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.firestore.CollectionReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+
+/**
+ * Screen for organizers to view chosen entrants for an event.
+ *
+ * Outstanding issues:
+ * - Event ID is currently hardcoded for testing.
+ * - Entrants are currently displayed by device ID only.
+ */
+public class ChosenEntrantsActivity extends AppCompatActivity {
+
+    private static final String TAG = "ChosenEntrantsActivity";
+    private static final String EVENT_ID = "JQRdL6qGdb8blRJubee0";
+
+    private FirebaseFirestore db;
+    private CollectionReference entrantsRef;
+
+    private ArrayList<String> chosenEntrantsList;
+    private ArrayAdapter<String> chosenEntrantsAdapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chosen_entrants);
+
+        db = FirebaseFirestore.getInstance();
+        entrantsRef = db.collection("events")
+                .document(EVENT_ID)
+                .collection("entrants");
+
+        TextView backButton = findViewById(R.id.chosenEntrantsBackButton);
+        ListView chosenEntrantsListView = findViewById(R.id.chosenEntrantsListView);
+
+        chosenEntrantsList = new ArrayList<>();
+        chosenEntrantsAdapter = new ArrayAdapter<>(
+                this,
+                R.layout.chosen_entrant_list_item,
+                R.id.chosenEntrantName,
+                chosenEntrantsList
+        );
+        chosenEntrantsListView.setAdapter(chosenEntrantsAdapter);
+
+        backButton.setOnClickListener(v -> finish());
+
+        loadChosenEntrants();
+    }
+
+    /**
+     * Loads entrants whose status is "selected" from Firestore and displays them.
+     */
+    private void loadChosenEntrants() {
+        entrantsRef.whereEqualTo("status", "selected")
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    chosenEntrantsList.clear();
+
+                    for (QueryDocumentSnapshot snapshot : queryDocumentSnapshots) {
+                        chosenEntrantsList.add(snapshot.getId());
+                    }
+
+                    chosenEntrantsAdapter.notifyDataSetChanged();
+
+                    if (chosenEntrantsList.isEmpty()) {
+                        Toast.makeText(this, "No chosen entrants found.", Toast.LENGTH_SHORT).show();
+                    } else {
+                        Toast.makeText(
+                                this,
+                                "Loaded " + chosenEntrantsList.size() + " chosen entrants.",
+                                Toast.LENGTH_SHORT
+                        ).show();
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Failed to load chosen entrants", e);
+                    Toast.makeText(this, "Failed to load chosen entrants.", Toast.LENGTH_SHORT).show();
+                });
+    }
+}

--- a/Icarus/app/src/main/res/drawable/my_image.xml
+++ b/Icarus/app/src/main/res/drawable/my_image.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/primary_container_highlighted" />
+    <corners android:radius="12dp" />
+</shape>

--- a/Icarus/app/src/main/res/layout/activity_chosen_entrants.xml
+++ b/Icarus/app/src/main/res/layout/activity_chosen_entrants.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/chosenEntrantsMain"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/primary"
+    android:padding="16dp">
+
+    <!-- Top bar -->
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="60dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="24dp"
+        android:background="@color/primary_container"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp">
+
+        <TextView
+            android:id="@+id/chosenEntrantsBackButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="‹"
+            android:textColor="@color/black"
+            android:textSize="@dimen/font_heading_size"
+            android:textStyle="normal" />
+
+        <TextView
+            android:id="@+id/chosenEntrantsTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="center"
+            android:text="Chosen Entrants"
+            android:textColor="@color/black"
+            android:textSize="@dimen/font_heading_size"
+            android:textStyle="normal" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="◉"
+            android:textColor="@color/black"
+            android:textSize="@dimen/font_text_size"
+            android:textStyle="normal" />
+    </LinearLayout>
+
+    <ListView
+        android:id="@+id/chosenEntrantsListView"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:divider="@color/primary_container_highlighted"
+        android:dividerHeight="1dp" />
+
+</LinearLayout>

--- a/Icarus/app/src/main/res/layout/chosen_entrant_list_item.xml
+++ b/Icarus/app/src/main/res/layout/chosen_entrant_list_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/chosenEntrantName"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp"
+    android:textColor="@color/black"
+    android:textSize="@dimen/font_text_size"
+    android:textStyle="normal" />


### PR DESCRIPTION
Implemented the Chosen Entrants screen using the updated Firestore schema by querying the event’s entrants subcollection for entrants with status == "selected".